### PR TITLE
feat: インデントスタイルを変更

### DIFF
--- a/client/src/components/spaces/doc/Doc.css
+++ b/client/src/components/spaces/doc/Doc.css
@@ -45,17 +45,7 @@
     cursor: grabbing;
 }
 
-/* ロック中の行のドラッグ無効化スタイル */
-.locked .dot {
-    cursor: not-allowed !important;
-    opacity: 0.5;
-    background-color: #ccc !important;
-}
 
-.locked .dot:hover {
-    background-color: #ccc !important;
-    transform: none !important;
-}
 
 /* ロック中のアイテム全体のスタイル */
 .locked {
@@ -108,28 +98,7 @@
     background: #f5fbff;
 }
 
-.dot {
-    margin-right: 8px;
-    user-select: none;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 20px;
-    color: #aaaaaa;
-    cursor: grab;
-    font-size: 20px;
-}
 
-.dot::before {
-    content: '●';
-    font-size: 20px;
-    line-height: 1;
-    letter-spacing: -2px;
-}
-
-.dot:active {
-    cursor: grabbing;
-}
 
 /* ホバー時に表示される追加ボタン（右側に表示） */
 .add-button {
@@ -224,16 +193,7 @@
     display: none !important;
 }
 
-/* ドラッグ・アンド・ドロップのロック状態 */
-.doc-comment-item.locked .dot {
-    cursor: not-allowed !important;
-    opacity: 0.5;
-}
 
-.doc-comment-item.locked .dot:hover {
-    background-color: #dc3545 !important;
-    transform: none !important;
-}
 
 /* ドラッグ中の状態 */
 .doc-comment-item.drag-disabled {

--- a/client/src/components/spaces/doc/DocRow.jsx
+++ b/client/src/components/spaces/doc/DocRow.jsx
@@ -196,22 +196,18 @@ const DocRow = ({ data, index, style }) => {
                             onMouseLeave={handleMouseLeave}
                         />
 
-                        {/* 見出し行の場合は.dotを非表示 */}
-                        {!isHeading && <span {...provided.dragHandleProps} className='dot' />}
-
                         {/* インデントボタン（見出し以外） */}
                         {!isHeading && !locked && (
                             <div className="indent-buttons">
-                                {currentIndent > 0 && (
+                                {currentIndent === 2 ? (
                                     <button
-                                        className="indent-button indent-decrease"
-                                        onClick={() => handleIndentChange(-1)}
+                                        className="indent-button indent-decrease-double"
+                                        onClick={() => handleIndentChange(-2)}
                                         title="インデントを戻す"
                                     >
-                                        ＜
+                                        ≪
                                     </button>
-                                )}
-                                {currentIndent < 2 && (
+                                ) : (
                                     <button
                                         className="indent-button indent-increase"
                                         onClick={() => handleIndentChange(1)}


### PR DESCRIPTION
このプルリクエストは、主に.dotドキュメントエディタの見出し以外の行からドラッグハンドルUI要素を削除し、関連するCSSを整理します。さらに、インデントコントロールを更新し、最大インデントレベル時に2段階の減少ができるようにしました。これらの変更により、インターフェースが簡素化され、コードが合理化されます。

UIと機能の変更
[1] [2] [3] [4]の関連するすべてのCSSスタイルと状態を含む、.dot見出し以外の行からドラッグハンドル要素を削除しました。DocRow.jsx.dot
≪インデント コントロールの更新: 現在のインデントがレベル 2 の場合、新しいボタン スタイルとアイコン ( )を使用して、減少ボタンで一度に 2 レベル分のインデントを減らすことができるようになりました。
コードのクリーンアップ
.dot要素とそのロック/ドラッグ無効状態に対する未使用および冗長なCSSルールを削除し、よりクリーンなスタイルシートを実現しました[1] [2] [3]